### PR TITLE
fix: add support for empty sendType values

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11935,6 +11935,9 @@ components:
             - VPDF
             - VM
             - VP
+            - ''
+            - 0
+            - null
           nullable: true
         creditNoteType:
           description: "Type of the creditNote. For more information on the different types, check\r\n    <a href='https://api.sevdesk.de/#section/Types-and-status-of-credit-notes'>this</a>\r\n."
@@ -14014,7 +14017,9 @@ components:
             - VPDF
             - VM
             - VP
+            - ''
             - 0
+            - null
           readOnly: true
         deliveryDateUntil:
           description: "If the delivery date should be a time range, another timestamp can be provided in this attribute\r\n     * to define a range from timestamp used in deliveryDate attribute to the timestamp used here."
@@ -15614,6 +15619,9 @@ components:
             - VPDF
             - VM
             - VP
+            - ''
+            - 0
+            - null
           nullable: true
       type: object
     Model_Order:


### PR DESCRIPTION
Adds support for `sendType` response values:
- `""`
- `"0"`
- `null` ([for nullable enums](https://github.com/OAI/OpenAPI-Specification/blob/main/proposals/2019-10-31-Clarify-Nullable.md#if-a-schema-specifies-nullable-true-and-enum-1-2-3-does-that-schema-allow-null-values-see-1900))

Fixes #45, fixes j-mastr/sevdesk-php-sdk#47