### PR TITLE
Add FAX as communication way type

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1452,6 +1452,7 @@ paths:
             type: string
             enum:
               - EMAIL
+              - FAX
               - MOBILE
               - PHONE
               - WEB

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10928,6 +10928,7 @@ components:
             - PHONE
             - WEB
             - MOBILE
+            - FAX
           example: EMAIL
           readOnly: true
         value:
@@ -11046,6 +11047,7 @@ components:
             - PHONE
             - WEB
             - MOBILE
+            - FAX
           example: EMAIL
         value:
           description: "The value of the communication way.<br>\r\n     For example the phone number, e-mail address or website."
@@ -11132,6 +11134,7 @@ components:
             - PHONE
             - WEB
             - MOBILE
+            - FAX
           example: EMAIL
         value:
           description: "The value of the communication way.<br>\r\n     For example the phone number, e-mail address or website."


### PR DESCRIPTION
FAX does not seem to be documented but has been a valid  communication way type and is delivered by the api so this should be included