### PR TITLE
empty response for save requests

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5284,7 +5284,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_Email'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_Email'
+                type: object
         '400':
           description: Bad request
         '401':

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6155,7 +6155,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/saveOrderResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/saveOrderResponse'
+                type: object
         '400':
           description: Bad request
         '401':
@@ -6223,7 +6226,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_OrderResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_OrderResponse'
+                type: object
         '400':
           description: Bad request
         '401':
@@ -6561,7 +6567,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_OrderResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_OrderResponse'
+                type: object
         '400':
           description: Bad Request
         '401':
@@ -6608,7 +6617,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_OrderResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_OrderResponse'
+                type: object
         '400':
           description: Bad Request
         '401':
@@ -6716,7 +6728,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_OrderResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_OrderResponse'
+                type: object
         '400':
           description: Bad request
         '401':
@@ -6841,7 +6856,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_OrderPosResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_OrderPosResponse'
+                type: object
         '400':
           description: Bad request
         '401':

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8322,7 +8322,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_TagResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_TagResponse'
+                type: object
         '401':
           description: Authentication required
         '500':
@@ -8406,7 +8409,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_TagCreateResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_TagCreateResponse'
+                type: object
         '401':
           description: Authentication required
         '500':

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5958,7 +5958,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_ChangeLayoutResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_ChangeLayoutResponse'
+                type: object
         '400':
           description: Bad request
         '401':
@@ -5993,7 +5996,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_ChangeLayoutResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_ChangeLayoutResponse'
+                type: object
         '400':
           description: Bad request
         '401':
@@ -6028,7 +6034,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_ChangeLayoutResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_ChangeLayoutResponse'
+                type: object
         '400':
           description: Bad request
         '401':

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4726,7 +4726,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/saveInvoiceResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/saveInvoiceResponse'
+                type: object
         '400':
           description: Bad request
         '401':
@@ -4990,7 +4993,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_InvoiceResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_InvoiceResponse'
+                type: object
         '400':
           description: Bad Request
         '401':
@@ -5135,7 +5141,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_InvoiceResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_InvoiceResponse'
+                type: object
         '400':
           description: Bad request
         '401':
@@ -5382,7 +5391,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_InvoiceResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_InvoiceResponse'
+                type: object
         '400':
           description: Bad request
         '401':

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -473,7 +473,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_CheckAccountResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_CheckAccountResponse'
+                type: object
         '400':
           description: Bad request
         '401':
@@ -727,7 +730,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_CheckAccountTransactionResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_CheckAccountTransactionResponse'
+                type: object
         '400':
           description: Bad request
         '401':
@@ -797,7 +803,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_CheckAccountTransactionResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_CheckAccountTransactionResponse'
+                type: object
         '400':
           description: Bad request
         '401':

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7195,7 +7195,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_VoucherResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_VoucherResponse'
+                type: object
         '400':
           description: Bad request
         '401':

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4394,7 +4394,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_Part'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_Part'
+                type: object
         '400':
           description: Bad request
         '401':
@@ -4462,7 +4465,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_Part'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_Part'
+                type: object
         '400':
           description: Bad request
         '401':

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8824,7 +8824,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_TextTemplateResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_TextTemplateResponse'
+                type: object
           description: created
         '400':
           description: invalid request
@@ -8882,7 +8885,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_TextTemplateResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_TextTemplateResponse'
+                type: object
           description: successful operation
         '400':
           description: invalid request

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2516,7 +2516,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/saveCreditNoteResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/saveCreditNoteResponse'
+                type: object
         '400':
           description: Bad request
         '401':
@@ -2793,7 +2796,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_CreditNote_sendByWithRender'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_CreditNote_sendByWithRender'
+                type: object
         '400':
           description: Bad request.
         '401':
@@ -2848,7 +2854,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_creditNoteResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_creditNoteResponse'
+                type: object
         '400':
           description: Bad request
         '401':

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1102,7 +1102,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_ContactResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_ContactResponse'
+                type: object
         '400':
           description: Bad request
         '401':
@@ -1172,7 +1175,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_ContactResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_ContactResponse'
+                type: object
         '400':
           description: Bad request
         '401':
@@ -1283,7 +1289,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_ContactAddressResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_ContactAddressResponse'
+                type: object
         '400':
           description: Bad request
         '401':
@@ -1389,7 +1398,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_ContactAddressResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_ContactAddressResponse'
+                type: object
         '400':
           description: Bad request
         '401':
@@ -1539,7 +1551,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_CommunicationWayResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_CommunicationWayResponse'
+                type: object
         '400':
           description: Bad request
         '401':
@@ -1643,7 +1658,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_CommunicationWayResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_CommunicationWayResponse'
+                type: object
         '400':
           description: Bad request
         '401':
@@ -1807,7 +1825,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_AccountingContactResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_AccountingContactResponse'
+                type: object
         '400':
           description: Bad request
         '401':
@@ -1880,7 +1901,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_AccountingContactResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_AccountingContactResponse'
+                type: object
         '400':
           description: Bad request
         '401':
@@ -2031,7 +2055,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_ContactCustomFieldResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_ContactCustomFieldResponse'
+                type: object
         '401':
           description: Authentication required
         '500':
@@ -2094,7 +2121,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_ContactCustomFieldResponse'
+                properties:
+                  objects:
+                    $ref: '#/components/schemas/Model_ContactCustomFieldResponse'
+                type: object
         '401':
           description: Authentication required
         '500':
@@ -2253,7 +2283,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Model_ContactCustomFieldSettingResponse'
+                properties:
+                  objects:
+                    $ref: >-
+                      #/components/schemas/Model_ContactCustomFieldSettingResponse
+                type: object
         '401':
           description: Authentication required
         '500':


### PR DESCRIPTION
Wraps all of the create/update responses in an `objects` property.

Fixes #51.