### PR TITLE
fix: add missing order object name

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14219,6 +14219,7 @@ components:
           default: Invoice
           enum:
             - Invoice
+            - Order
         invoiceNumber:
           description: The invoice number
           type: string


### PR DESCRIPTION
Object name for invoices can be **Order** if related object is an order