### PR TITLE
Fix several voucher related properties

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17364,6 +17364,8 @@ components:
           type: string
           nullable: true
           readOnly: true
+          pattern: >-
+            ^P(?!$)(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?=\d)(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$
         recurringStartDate:
           description: "The date when the recurring vouchers start being generated.<br>\r\n     Necessary attribute for all recurring vouchers."
           type: string
@@ -17834,9 +17836,9 @@ components:
           enum:
             - '50'
             - '100'
+            - '1000'
             - '150'
             - '750'
-            - '1000'
           example: '50'
           nullable: true
         sumNet:
@@ -18008,6 +18010,8 @@ components:
           description: "The DateInterval in which recurring vouchers are generated.<br>\r\n     Necessary attribute for all recurring vouchers."
           type: string
           nullable: true
+          pattern: >-
+            ^P(?!$)(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?=\d)(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$
         recurringStartDate:
           description: "The date when the recurring vouchers start being generated.<br>\r\n     Necessary attribute for all recurring vouchers."
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11850,14 +11850,7 @@ components:
 
                 For small business owner ("Kleinunternehmer") it can be:
                   - `11` - Steuer nicht erhoben nach §19UStG - tax rates: 0.0 - replaces `"taxType": "ss"`
-              type: string
-              enum:
-                - '1'
-                - '2'
-                - '3'
-                - '4'
-                - '5'
-                - '11'
+              type: integer
             objectName:
               description: Name of the object. Must always be TaxRule
               type: string
@@ -12208,14 +12201,7 @@ components:
 
                 For small business owner ("Kleinunternehmer") it can be:
                   - `11` - Steuer nicht erhoben nach §19UStG - tax rates: 0.0 - replaces `"taxType": "ss"`
-              type: string
-              enum:
-                - '1'
-                - '2'
-                - '3'
-                - '4'
-                - '5'
-                - '11'
+              type: integer
             objectName:
               description: Name of the object. Must always be TaxRule
               type: string
@@ -13082,14 +13068,7 @@ components:
 
                 For small business owner ("Kleinunternehmer") it can be:
                   - `11` - Steuer nicht erhoben nach §19UStG - tax rates: 0.0 - replaces `"taxType": "ss"`
-              type: string
-              enum:
-                - '1'
-                - '2'
-                - '3'
-                - '4'
-                - '5'
-                - '11'
+              type: integer
             objectName:
               description: Name of the object. Must always be TaxRule
               type: string
@@ -14388,14 +14367,7 @@ components:
 
                 For small business owner ("Kleinunternehmer") it can be:
                   - `11` - Steuer nicht erhoben nach §19UStG - tax rates: 0.0 - replaces `"taxType": "ss"`
-              type: string
-              enum:
-                - '1'
-                - '2'
-                - '3'
-                - '4'
-                - '5'
-                - '11'
+              type: integer
             objectName:
               description: Name of the object. Must always be TaxRule
               type: string
@@ -15569,14 +15541,7 @@ components:
 
                 For small business owner ("Kleinunternehmer") it can be:
                   - `11` - Steuer nicht erhoben nach §19UStG - tax rates: 0.0 - replaces `"taxType": "ss"`
-              type: string
-              enum:
-                - '1'
-                - '2'
-                - '3'
-                - '4'
-                - '5'
-                - '11'
+              type: integer
             objectName:
               description: Name of the object. Must always be TaxRule
               type: string
@@ -15920,14 +15885,7 @@ components:
 
                 For small business owner ("Kleinunternehmer") it can be:
                   - `11` - Steuer nicht erhoben nach §19UStG - tax rates: 0.0 - replaces `"taxType": "ss"`
-              type: string
-              enum:
-                - '1'
-                - '2'
-                - '3'
-                - '4'
-                - '5'
-                - '11'
+              type: integer
             objectName:
               description: Name of the object. Must always be TaxRule
               type: string
@@ -16639,14 +16597,7 @@ components:
 
                 For small business owner ("Kleinunternehmer") it can be:
                   - `11` - Steuer nicht erhoben nach §19UStG - tax rates: 0.0 - replaces `"taxType": "ss"`
-              type: string
-              enum:
-                - '1'
-                - '2'
-                - '3'
-                - '4'
-                - '5'
-                - '11'
+              type: integer
             objectName:
               description: Name of the object. Must always be TaxRule
               type: string
@@ -17334,14 +17285,7 @@ components:
 
                 For small business owner ("Kleinunternehmer") it can be:
                   - `11` - Steuer nicht erhoben nach §19UStG (tax rates: 0.0) - replaces `"taxType": "ss"`
-              type: string
-              enum:
-                - '1'
-                - '2'
-                - '3'
-                - '4'
-                - '5'
-                - '11'
+              type: integer
             objectName:
               description: Name of the object. Must always be TaxRule
               type: string
@@ -17418,17 +17362,6 @@ components:
         recurringInterval:
           description: "The DateInterval in which recurring vouchers are generated.<br>\r\n     Necessary attribute for all recurring vouchers."
           type: string
-          enum:
-            - P0Y0M1W
-            - P0Y0M2W
-            - P0Y1M0W
-            - P0Y3M0W
-            - P0Y6M0W
-            - P1Y0M0W
-            - P2Y0M0W
-            - P3Y0M0W
-            - P4Y0M0W
-            - P5Y0M0W
           nullable: true
           readOnly: true
         recurringStartDate:
@@ -17901,6 +17834,8 @@ components:
           enum:
             - '50'
             - '100'
+            - '150'
+            - '750'
             - '1000'
           example: '50'
           nullable: true
@@ -17978,14 +17913,7 @@ components:
 
                 For small business owner ("Kleinunternehmer") it can be:
                   - `11` - Steuer nicht erhoben nach §19UStG (tax rates: 0.0) - replaces `"taxType": "ss"`
-              type: string
-              enum:
-                - '1'
-                - '2'
-                - '3'
-                - '4'
-                - '5'
-                - '11'
+              type: integer
             objectName:
               description: Name of the object. Must always be TaxRule
               type: string
@@ -18079,17 +18007,6 @@ components:
         recurringInterval:
           description: "The DateInterval in which recurring vouchers are generated.<br>\r\n     Necessary attribute for all recurring vouchers."
           type: string
-          enum:
-            - P0Y0M1W
-            - P0Y0M2W
-            - P0Y1M0W
-            - P0Y3M0W
-            - P0Y6M0W
-            - P1Y0M0W
-            - P2Y0M0W
-            - P3Y0M0W
-            - P4Y0M0W
-            - P5Y0M0W
           nullable: true
         recurringStartDate:
           description: "The date when the recurring vouchers start being generated.<br>\r\n     Necessary attribute for all recurring vouchers."
@@ -18440,14 +18357,7 @@ components:
 
                 For small business owner ("Kleinunternehmer") it can be:
                   - `11` - Steuer nicht erhoben nach §19UStG (tax rates: 0.0) - replaces `"taxType": "ss"`
-              type: string
-              enum:
-                - '1'
-                - '2'
-                - '3'
-                - '4'
-                - '5'
-                - '11'
+              type: integer
             objectName:
               description: Name of the object. Must always be TaxRule
               type: string
@@ -19703,14 +19613,7 @@ components:
 
                 For small business owner ("Kleinunternehmer") it can be:
                   - `11` - Steuer nicht erhoben nach §19UStG - tax rates: 0.0 - replaces `"taxType": "ss"`
-              enum:
-                - '1'
-                - '11'
-                - '2'
-                - '3'
-                - '4'
-                - '5'
-              type: string
+              type: integer
             objectName:
               description: Name of the object. Must always be TaxRule
               enum:


### PR DESCRIPTION
Vouchers could not be retrieved with the existing API description because various properties were described incompletely or too restrictively. The following adjustments have been made:

- **Remove incomplete tax rule ID enumeration**: There are more tax rule IDs than are displayed in the API documentation (e.g. ‘9’). On the other hand, the enumeration used did not include values that were listed in the API documentation (e.g. ‘17’). An enumeration at this point seems fundamentally too restrictive.
- **Remove incomplete recurrence interval enumeration**: The enumeration was too restrictive, there can be any number of values in addition to those included (e.g. ‘P0Y1M’ and ‘P0Y1M0W’ are equivalent, but only ‘P0Y1M0W’ was included in the enumeration).
- **Add missing voucher statuses**: The documented voucher statuses 150 and 750 have been added.